### PR TITLE
slurm_ctl_conf_t changed

### DIFF
--- a/slurm-https.go
+++ b/slurm-https.go
@@ -1119,7 +1119,7 @@ func load_ctl_conf(w http.ResponseWriter, r *http.Request) {
 	obj.Add(&opt)
 
 	obj.Run(w, r, func() {
-		var slres *C.slurm_ctl_conf_t
+		var slres *C.slurm_conf_t
 
 		ret := C.slurm_load_ctl_conf(opt.update_time, &slres)
 


### PR DESCRIPTION
 -- slurm_ctl_conf_t has been renamed to slurm_conf_t.
see release notes
https://github.com/SchedMD/slurm/blob/d3585a55d5820ee7ae0108d0b730ce9e9be661f8/RELEASE_NOTES